### PR TITLE
Build with latest Stackage LTS (16.4)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.0
+resolver: lts-16.4
 
 packages:
 - .


### PR DESCRIPTION
Fixes doctest failures.

Closes #6